### PR TITLE
Add Storage Account Default Share Permissions Policy

### DIFF
--- a/resources/azure/policy/storage_account/disable_default_share_permission.json
+++ b/resources/azure/policy/storage_account/disable_default_share_permission.json
@@ -1,0 +1,26 @@
+{
+    "properties": {
+        "displayName": "[Custom] Storage Account Disable Default Share Permission",
+        "policyType": "Custom",
+        "mode": "All",
+        "description": "If the Storage Account attribute called defaultSharePermission is present, its value should not contain the string StorageFileDataSmbShare",
+        "parameters": {},
+        "policyRule": {
+            "if": {
+                "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Storage/storageAccounts"
+                },
+                {
+                    "field": "Microsoft.Storage/storageAccounts/azureFilesIdentityBasedAuthentication.defaultSharePermission",
+                    "contains": "StorageFileDataSmbShare"
+                }
+                ]
+      },
+            "then": {
+                "effect": "deny"
+            }
+        }
+    }
+  }


### PR DESCRIPTION
Adding Azure Policy note that can be used to enforce Storage Accounts always have their default share-level permission set to disable. This forces Azure Role Assignments to be used to grant Storage Account Share access. 